### PR TITLE
delete fix：いいね一覧、コメント一覧の削除機能の修正

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -11,7 +11,6 @@ class AccountsController < ApplicationController
   end
 
   def comment
-    @posts = Favorite.where(user_id: params[:id]).includes(:post).includes(:user).page(params[:page]).per(10)
     @comments = Comment.where(user_id: params[:id]).includes(:post).includes(:user).page(params[:page]).per(10)
   end
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -20,11 +20,11 @@ class CommentsController < ApplicationController
   end
 
   def destroy
-    @post = Post.find(params[:post_id])
-    @post_comments = @post.comments
-    Comment.find_by(id: params[:id], post_id: params[:post_id]).destroy
+    @user = current_user
+    @comment = Comment.find(params[:id])
+    @comment.destroy
     flash[:notice] = 'コメントを削除しました'
-    redirect_to post_path(@post)
+    redirect_to comment_account_path(@user)
   end
 
   private

--- a/app/views/accounts/comment.html.erb
+++ b/app/views/accounts/comment.html.erb
@@ -36,6 +36,11 @@
               </div>
               <div class="post_contents_right">
                 <div><%= p.created_at.strftime("%Y年%m月%d日") %></div>
+                <% unless current_user.nil? %>
+                  <% if p.user.id == current_user.id %>
+                    <div><%= link_to "削除する", post_comment_path(p.post.id, p.id), data: { confirm: "本当に削除しますか？" }, method: :delete %></div>
+                  <% end %>
+                <% end %>
               </div>
             </div>
           </div>

--- a/app/views/accounts/favorite_show.html.erb
+++ b/app/views/accounts/favorite_show.html.erb
@@ -31,7 +31,7 @@
           <div class="post">
             <div class="post_contents">
               <div class="post_contents_left">
-                <div><%= link_to p.user.name, account_path(p.user.id) %></div>
+                <div><%= link_to p.post.user.name, account_path(p.user.id) %></div>
                 <div><%= link_to p.post.title, post_path(p.post.id), data: { turbo: false } %></div>
                 <div><%= p.post.body %></div>
                 <div><%= p.post.address %></div>
@@ -48,8 +48,8 @@
               <div class="post_contents_right">
                 <div><%= p.post.created_at.strftime("%Y年%m月%d日") %></div>
                 <% unless current_user.nil? %>
-                  <% if @user.id == current_user.id %>
-                    <div><%= link_to "削除する", post_path(p.id), data: { confirm: "本当に削除しますか？", turbo_confirm: "本当に削除しますか？" }, method: :delete %></div>
+                  <% if p.post.user.id == current_user.id %>
+                    <div><%= link_to "削除する", post_path(p.post.id), data: { confirm: "本当に削除しますか？", turbo_confirm: "本当に削除しますか？" }, method: :delete %></div>
                   <% end %>
                 <% end %>
               </div>


### PR DESCRIPTION
◼︎概要
いいね一覧、コメント一覧の削除機能の修正

◼︎詳細
①いいねした投稿の投稿者名が、いいねしたユーザーになっており、投稿に紐づくユーザー名ではなかったため修正
②コメント一覧に削除機能がなかったため追加。