### PR TITLE
Fix20240501：リンクの修正

### DIFF
--- a/app/views/accounts/favorite_show.html.erb
+++ b/app/views/accounts/favorite_show.html.erb
@@ -31,7 +31,7 @@
           <div class="post">
             <div class="post_contents">
               <div class="post_contents_left">
-                <div><%= link_to p.post.user.name, account_path(p.user.id) %></div>
+                <div><%= link_to p.post.user.name, account_path(p.post.user.id) %></div>
                 <div><%= link_to p.post.title, post_path(p.post.id), data: { turbo: false } %></div>
                 <div><%= p.post.body %></div>
                 <div><%= p.post.address %></div>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -89,9 +89,13 @@
         <% @posts.each do |p| %>
           <div class="post">
             <% if p.user.image.attached? %>
-              <%= image_tag p.user.image, class:"user_image_post_icon" %>
+              <%= link_to account_path(p.user.id) do %>
+                <%= image_tag p.user.image, class:"user_image_post_icon" %>
+              <% end %>
             <% else %>
-              <%= image_tag 'icon.png', class:"user_image_post_icon" %>
+              <%= link_to account_path(p.user.id) do %>
+                <%= image_tag 'icon.png', class:"user_image_post_icon" %>
+              <% end %>
             <% end %>
             <div class="post_contents">
               <div class="post_contents_left">


### PR DESCRIPTION
◼︎概要
アカウントページへのリンク修正

◼︎詳細
①いいね一覧のユーザー名をクリックしても自分のマイページにしか遷移しないエラーを修正
②投稿一覧ページのユーザーアイコン画像にアカウントページへのリンク埋め込み